### PR TITLE
Install latest Kubectl version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ LATEST_RELEASE=$(curl https://storage.googleapis.com/kubernetes-release/release/
 KUBECTL_VERSION=${LATEST_RELEASE}
 
 function install_kubectl() {
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+    wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
     chmod +x ./kubectl && mv kubectl /usr/local/bin/
 }
 

--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,11 @@ apk info
 mkdir -p /opt/download
 cd /opt/download
 
+LATEST_RELEASE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTL_VERSION=${LATEST_RELEASE}
 
 function install_kubectl() {
-    wget https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
     chmod +x ./kubectl && mv kubectl /usr/local/bin/
 }
 

--- a/install.sh
+++ b/install.sh
@@ -12,11 +12,11 @@ apk info
 mkdir -p /opt/download
 cd /opt/download
 
-LATEST_RELEASE=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+LATEST_RELEASE=$(curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTL_VERSION=${LATEST_RELEASE}
 
 function install_kubectl() {
-    wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+    wget --no-verbose https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
     chmod +x ./kubectl && mv kubectl /usr/local/bin/
 }
 

--- a/install.sh
+++ b/install.sh
@@ -22,3 +22,5 @@ function install_kubectl() {
 
 install_kubectl
 
+# Verify the kubectl installation
+kubectl version

--- a/install.sh
+++ b/install.sh
@@ -23,4 +23,4 @@ function install_kubectl() {
 install_kubectl
 
 # Verify the kubectl installation
-kubectl version
+kubectl version --client


### PR DESCRIPTION
Part of the https://github.com/bitovi/bitops/issues/307

Previously, the Kubectl version was pinned in the plugin installation script.
With this PR when packaging the Kubectl plugin in the custom-built BitOps image, the latest version will be downloaded by default.